### PR TITLE
WIP: Compatible Node modules in dependencies and allow them to be built without prefixes

### DIFF
--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -53,6 +53,65 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 				return result;
 			}
 		);
+		/**
+		 * TODO:  https://github.com/denoland/deno-astro-adapter/blob/9418fa6306204cfbfc96905b2248ee59a511560b/src/index.ts#L107
+		 */
+		const COMPATIBLE_NODE_MODULES = [
+			'assert',
+			'assert/strict',
+			'async_hooks',
+			'buffer',
+			'child_process',
+			'cluster',
+			'console',
+			'constants',
+			'crypto',
+			'dgram',
+			'diagnostics_channel',
+			'dns',
+			'events',
+			'fs',
+			'fs/promises',
+			'http',
+			// 'http2',
+			'https',
+			'inspector',
+			'module',
+			'net',
+			'os',
+			'path',
+			'path/posix',
+			'path/win32',
+			'perf_hooks',
+			'process',
+			'punycode',
+			'querystring',
+			'readline',
+			'repl',
+			'stream',
+			'stream/promises',
+			'stream/web',
+			'string_decoder',
+			'sys',
+			'timers',
+			'timers/promises',
+			// 'tls',
+			'trace_events',
+			'tty',
+			'tls',
+			'url',
+			'util',
+			'util/types',
+			// 'v8',
+			// 'vm',
+			// 'wasi',
+			// 'webcrypto',
+			'worker_threads',
+			'zlib',
+		];
+		const filter = new RegExp(COMPATIBLE_NODE_MODULES.map((mod) => `(^${mod}$)`).join('|'));
+		pluginBuild.onResolve({ filter }, (args) => ({ path: 'node:' + args.path, external: true }));
+
 		// Wait until the build finishes to log warnings, so that all files which import a package
 		// can be collated
 		pluginBuild.onEnd(() => {


### PR DESCRIPTION
This patch introduces a Node compatibility filter to the esbuild plugin, incorporating code from the [deno-astro-adapter](https://github.com/denoland/deno-astro-adapter). The filter checks if the names of specific Node modules are included in a predefined list. If a module is listed, its path is modified by appending the node: prefix and marking it as external. 

```typescript
import mysql from 'mysql2/promise';

const dbConfig = {
	host: 'localhost',
	user: 'root',
	password: 'password',
	database: 'mysql'
};

export default {
	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
		let connection;
		try {
			connection = await mysql.createConnection(dbConfig);
			const [rows] = await connection.execute('SELECT * FROM users');
			return new Response(JSON.stringify(rows), {
				headers: { 'content-type': 'application/json' }
			});
		} catch (error) {
			return new Response(`Database connection error: ${error}`, { status: 500 });
		} finally {
			if (connection) {
				await connection.end();
			}
		}
	},
};
```

```bash
$ node ./packages/wrangler/wrangler-dist/cli.js build

▲ [WARNING] Deprecation: `wrangler build` has been deprecated.

  Please refer to https://developers.cloudflare.com/workers/wrangler/migration/deprecations/#build
  for more information.
  Attempting to run `wrangler deploy --dry-run --outdir=dist` for you instead:


 ⛅️ wrangler 3.53.1
-------------------
--dry-run: exiting now.
Total Upload: 1237.35 KiB / gzip: 354.32 KiB
```